### PR TITLE
Adds "img" dir to npm whitelisted files

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "main": "dist/inspire-tree.js",
   "files": [
     "dist",
+    "img",
     "*.json",
     "LICENSE",
     "README.md"


### PR DESCRIPTION
The npm distributed files did not include the img/spinner.gif file. This is an issue when importing the sass files directly from node_modules (like when using webpack). 

For example, my `@import '~inspire-tree/dist/scss/tree';` statement finds everything in node_modules just fine, everything but the images because npm didn't know to bring in the images.  

Thanks!

And +1 for this project. I'm so sick and tired of having build-tools dictated to me by the many, many commonly used libraries out there (chosen, select2, bootstrap, foundation, ........). It's refreshing to come across a project that respects the modularity of javascript and web development. It's refreshing to see a tree widget that doesn't use jQuery. Thank you for sharing this!