### PR TITLE
Search fixes. Fixes #121

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -347,12 +347,13 @@ export default class InspireTree extends EventEmitter2 {
     }
 
     /**
-     * Shows all nodes and collapses parents.
+     * Clears matched nodes, shows all nodes and collapses parents.
      *
      * @category Tree
      * @return {Tree} Tree instance.
      */
     clearSearch() {
+        this.matched().state('matched', false);
         return this.showDeep().collapseDeep().tree();
     }
 
@@ -986,7 +987,7 @@ export default class InspireTree extends EventEmitter2 {
 
         // Don't search if query empty
         if (!query || (_.isString(query) && _.isEmpty(query))) {
-            return tree.clearSearch();
+            return Promise.resolve(tree.clearSearch());
         }
 
         tree.dom.batch();

--- a/test/tree/search.spec.js
+++ b/test/tree/search.spec.js
@@ -28,6 +28,10 @@ describe('Tree.search', function() {
         expect(tree.search('fox').then).to.be.a('function');
     });
 
+    it('returns a promise for empty search', function() {
+        expect(tree.search('').then).to.be.a('function');
+    });
+
     it('returns matches for a string query', function(done) {
         tree.search('fox').then(function(matches) {
             expect(matches).to.have.length(1);
@@ -66,6 +70,8 @@ describe('Tree.search', function() {
 
     it('clears the search', function() {
         tree.clearSearch();
+
+        expect(tree.matched()).to.have.length(0);
 
         expect(tree.node(1).hidden()).to.be.false;
         expect(tree.node(2).hidden()).to.be.false;


### PR DESCRIPTION
Clear search early return now returns a promise and clears 'matched' state for previously matched nodes