### PR TITLE
Add a few additional properties to typescript definition

### DIFF
--- a/inspire-tree.d.ts
+++ b/inspire-tree.d.ts
@@ -280,31 +280,7 @@ export class TreeNode {
     constructor(tree: InspireTree);
     text: string;
     id: string;
-    itree?: {
-        a?: {
-            attributes?: any
-        },
-        icon?: string,
-        li?: {
-            attributes?: any
-        },
-        state?: {
-            checked?: boolean,
-            collapsed?: boolean,
-            draggable?: boolean,
-            'drop-target'?: boolean,
-            editable?: boolean,
-            focused?: boolean,
-            hidden?: boolean,
-            indeterminate?: boolean,
-            loading?: boolean,
-            matched?: boolean,
-            removed?: boolean,
-            rendered?: boolean,
-            selectable?: boolean,
-            selected?: boolean,
-        }
-    };
+    itree?: NodeConfig['itree'];
     context(): TreeNodes;
     copy(hierarchy?: boolean): TreeNode;
     copyHierarchy(excludeNode?: boolean): TreeNode;

--- a/inspire-tree.d.ts
+++ b/inspire-tree.d.ts
@@ -279,6 +279,7 @@ export class TreeNode {
     constructor(tree: InspireTree, source: any|TreeNode);
     constructor(tree: InspireTree);
     text: string;
+    id: string;
     itree?: {
         a?: {
             attributes?: any

--- a/inspire-tree.d.ts
+++ b/inspire-tree.d.ts
@@ -277,6 +277,7 @@ export class TreeNode {
     constructor(tree: InspireTree, source: any|TreeNode, excludeKeys: Array<string>);
     constructor(tree: InspireTree, source: any|TreeNode);
     constructor(tree: InspireTree);
+    text: string;
     context(): TreeNodes;
     copy(hierarchy?: boolean): TreeNode;
     copyHierarchy(excludeNode?: boolean): TreeNode;

--- a/inspire-tree.d.ts
+++ b/inspire-tree.d.ts
@@ -150,6 +150,8 @@ export class InspireTree extends EventEmitter2 {
     hide(): TreeNodes;
     hideDeep(): TreeNodes;
     id: string | number;
+    config: any;
+    preventDeselection: boolean;
     indeterminate(full?: boolean): TreeNodes;
     insertAt(index: number, object: any): TreeNode;
     invoke(methods: string|Array<string>): TreeNodes;

--- a/inspire-tree.d.ts
+++ b/inspire-tree.d.ts
@@ -65,6 +65,7 @@ export interface Config {
         require?: boolean;
     };
     sort?: string;
+    multiselect?: boolean;
 }
 
 export interface NodeConfig {
@@ -278,6 +279,31 @@ export class TreeNode {
     constructor(tree: InspireTree, source: any|TreeNode);
     constructor(tree: InspireTree);
     text: string;
+    itree?: {
+        a?: {
+            attributes?: any
+        },
+        icon?: string,
+        li?: {
+            attributes?: any
+        },
+        state?: {
+            checked?: boolean,
+            collapsed?: boolean,
+            draggable?: boolean,
+            'drop-target'?: boolean,
+            editable?: boolean,
+            focused?: boolean,
+            hidden?: boolean,
+            indeterminate?: boolean,
+            loading?: boolean,
+            matched?: boolean,
+            removed?: boolean,
+            rendered?: boolean,
+            selectable?: boolean,
+            selected?: boolean,
+        }
+    };
     context(): TreeNodes;
     copy(hierarchy?: boolean): TreeNode;
     copyHierarchy(excludeNode?: boolean): TreeNode;

--- a/inspire-tree.d.ts
+++ b/inspire-tree.d.ts
@@ -150,7 +150,7 @@ export class InspireTree extends EventEmitter2 {
     hide(): TreeNodes;
     hideDeep(): TreeNodes;
     id: string | number;
-    config: any;
+    config: Config;
     preventDeselection: boolean;
     indeterminate(full?: boolean): TreeNodes;
     insertAt(index: number, object: any): TreeNode;


### PR DESCRIPTION
Code editors show typescript issues with these properties. Stating they do not exist in the InspireTree class. Adding them to the TypeScript definition file, so they stop complaining or throw build errors.